### PR TITLE
Fix for duplicate work items

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up Go (or replace with your stack)
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24.5'  # Change to your Go version
+          go-version: '1.25.5'  # Change to your Go version
 
       - name: run tests
         run: |

--- a/cmd/worksStop.go
+++ b/cmd/worksStop.go
@@ -18,7 +18,6 @@ var worksStopCmd = &cobra.Command{
 			cmd.PrintErrln("Invalid WorkID, must be an integer")
 			return
 		}
-
 		if !services.WorkStorage.Exists(workID) {
 			cmd.PrintErrln("Work with ID", workID, "does not exist.")
 			return
@@ -37,12 +36,16 @@ var worksStopCmd = &cobra.Command{
 		return
 	}
 
-	err = services.WorkStorage.SaveWorks()
-	if err != nil {
-		cmd.PrintErrln("Error saving works:", err)
-		return
-	}
+		err = services.WorkStorage.SaveWorks()
+		if err != nil {
+			cmd.PrintErrln("Error saving works:", err)
+			return
+		}
 
-	cmd.Println("Work", workID, "stopped successfully.")
+		cmd.Println("Work", workID, "stopped successfully.")
+	},
+}
+
+func init() {
 	worksCmd.AddCommand(worksStopCmd)
 }

--- a/cmd/worksStop.go
+++ b/cmd/worksStop.go
@@ -24,18 +24,25 @@ var worksStopCmd = &cobra.Command{
 			return
 		}
 
-		if len(args) > 1 {
-			description := args[1]
-			services.WorkStorage.Stop(workID, description)
-		} else {
-			services.WorkStorage.Stop(workID, "")
-		}
+	var stopErr error
+	if len(args) > 1 {
+		description := args[1]
+		stopErr = services.WorkStorage.Stop(workID, description)
+	} else {
+		stopErr = services.WorkStorage.Stop(workID, "")
+	}
 
-		_ = services.WorkStorage.SaveWorks()
+	if stopErr != nil {
+		cmd.PrintErrln("Error stopping work:", stopErr)
+		return
+	}
 
-	},
-}
+	err = services.WorkStorage.SaveWorks()
+	if err != nil {
+		cmd.PrintErrln("Error saving works:", err)
+		return
+	}
 
-func init() {
+	cmd.Println("Work", workID, "stopped successfully.")
 	worksCmd.AddCommand(worksStopCmd)
 }

--- a/services/works.go
+++ b/services/works.go
@@ -113,21 +113,28 @@ func (ws *Works) SaveWorks() error {
 
 // Stop a work item by its ID.
 // If a description is provided, it updates the work's description.
-func (ws *Works) Stop(id int64, description string) {
-	work := ws.GetByID(id)
-	if work == nil {
-		return
+// Returns an error if the work is not found or already stopped.
+func (ws *Works) Stop(id int64, description string) error {
+	for i := range *ws {
+		if (*ws)[i].ID == id {
+			// Check if already stopped
+			if (*ws)[i].EndDate != nil {
+				return fmt.Errorf("work %d is already stopped", id)
+			}
+			
+			// Update the existing work item in place
+			endDate := time.Now()
+			(*ws)[i].EndDate = &endDate
+			
+			// If description is provided, update it
+			if description != "" {
+				(*ws)[i].Description = description
+			}
+			
+			return nil
+		}
 	}
-
-	endDate := time.Now()
-	work.EndDate = &endDate
-	// If description is provided, update it
-	if description != "" {
-		work.Description = description
-	}
-
-	// Update the work in the storage
-	*ws = append(*ws, *work)
+	return fmt.Errorf("work %d not found", id)
 }
 
 // Remove a work item by its ID.


### PR DESCRIPTION
Closes #7 

- Updated Stop() method to update in-place instead of appending
- Changed return type to error for proper error handling
- Added validation to prevent stopping already-stopped work
- Added error for work not found
